### PR TITLE
Numpy scikit version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ MABWiser is available to install as `pip install mabwiser`. It can also be insta
 
 Please submit bug reports and feature requests as [Issues](https://github.com/fidelity/mabwiser/issues).
 
-
 ## Citation
 
 If you use MABWiser in a publication, please cite it as:

--- a/mabwiser/base_mab.py
+++ b/mabwiser/base_mab.py
@@ -191,7 +191,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
         n_jobs = self._effective_jobs(n_contexts, self.n_jobs)
 
         # Partition contexts between jobs
-        n_contexts_per_job = np.full(n_jobs, n_contexts // n_jobs, dtype=np.int)
+        n_contexts_per_job = np.full(n_jobs, n_contexts // n_jobs, dtype=int)
         n_contexts_per_job[:n_contexts % n_jobs] += 1
         starts = np.cumsum(n_contexts_per_job)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib
-numpy
+numpy<1.20.0
 pandas
-scikit-learn>=0.22.0
+scikit-learn>=0.22.0,<0.24.0
 scipy
 seaborn>=0.9.0


### PR DESCRIPTION
Fixing warnings for np.int as this gets deprecated in numpy 1.20.0+ and making forward-looking dtype change in base_mab for numpy 1.20.0+

Specifying sklearn needs to be below 0.24.0 so that unit tests don't fail.