### PR TITLE
Fix NoReturn return type annotations

### DIFF
--- a/docsrc/new_bandit.rst
+++ b/docsrc/new_bandit.rst
@@ -113,7 +113,7 @@ Here is, at a high-level, what you need to implement in your bandit policy:
             # These fields are declared here and initialized to zero.
             self.my_value_to_arm = dict.fromkeys(self.arms, 0)
 
-        def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+        def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
             # TODO:
             # This method trains your algorithm from scratch each time its called.
             # You might need to reset the internal fields
@@ -124,7 +124,7 @@ Here is, at a high-level, what you need to implement in your bandit policy:
             # This automatically activates parallelization in the training phase.
             self._parallel_fit(decisions, rewards, contexts)
 
-        def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+        def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
             # This method trains your algorithm in a continuous fashion.
             # Unlike fit() operation, the partial_fit() does not reset internal fields typically.
             # This allows us to continue learning online

--- a/mabwiser/approximate.py
+++ b/mabwiser/approximate.py
@@ -5,7 +5,7 @@ import abc
 from collections import defaultdict
 from copy import deepcopy
 from itertools import chain
-from typing import List, NoReturn, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -23,7 +23,7 @@ from mabwiser.utils import Arm, _BaseRNG, create_rng
 
 class _ApproximateNeighbors(_Neighbors, metaclass=abc.ABCMeta):
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         super().fit(decisions, rewards, contexts)
 
         # Initialize planes
@@ -33,7 +33,7 @@ class _ApproximateNeighbors(_Neighbors, metaclass=abc.ABCMeta):
         self._fit_operation(contexts, context_start=0)
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
         start = len(self.contexts)
 
         super().partial_fit(decisions, rewards, contexts)

--- a/mabwiser/base_mab.py
+++ b/mabwiser/base_mab.py
@@ -7,7 +7,7 @@ This module defines the abstract base class for contextual multi-armed bandit al
 
 import abc
 from itertools import chain
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, Dict, List, Optional
 import multiprocessing as mp
 
 from joblib import Parallel, delayed
@@ -76,7 +76,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
 
         self.arm_to_expectation: Dict[Arm, float] = dict.fromkeys(self.arms, 0)
 
-    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> None:
         """Introduces a new arm to the bandit.
 
         Adds the new arm with zero expectations and
@@ -87,7 +87,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def fit(self, decisions: np.ndarray, rewards: np.ndarray,
-            contexts: Optional[np.ndarray] = None) -> NoReturn:
+            contexts: Optional[np.ndarray] = None) -> None:
         """Abstract method.
 
         Fits the multi-armed bandit to the given
@@ -97,7 +97,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
         """Abstract method.
 
         Updates the multi-armed bandit with the given
@@ -122,7 +122,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> None:
         """Abstract method.
 
         Updates the multi-armed bandit with the new arm.
@@ -131,7 +131,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _fit_arm(self, arm: Arm, decisions: np.ndarray, rewards: np.ndarray,
-                 contexts: Optional[np.ndarray] = None) -> NoReturn:
+                 contexts: Optional[np.ndarray] = None) -> None:
         """Abstract method.
 
         Fit operation for individual arm.

--- a/mabwiser/clusters.py
+++ b/mabwiser/clusters.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Callable, List, NoReturn, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import numpy as np
 from sklearn.cluster import KMeans, MiniBatchKMeans
@@ -48,7 +48,7 @@ class _Clusters(BaseMAB):
         reset(self.arm_to_expectation, np.nan)
 
     def fit(self, decisions: np.ndarray, rewards: np.ndarray,
-            contexts: Optional[np.ndarray] = None) -> NoReturn:
+            contexts: Optional[np.ndarray] = None) -> None:
 
         # Set the historical data for prediction
         self.decisions = decisions
@@ -67,7 +67,7 @@ class _Clusters(BaseMAB):
         self._fit_operation()
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
 
         # Binarize the rewards if using Thompson Sampling
         if isinstance(self.lp_list[0], _ThompsonSampling) and self.lp_list[0].binarizer:

--- a/mabwiser/greedy.py
+++ b/mabwiser/greedy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
@@ -19,7 +19,7 @@ class _EpsilonGreedy(BaseMAB):
         self.arm_to_sum = dict.fromkeys(self.arms, 0)
         self.arm_to_count = dict.fromkeys(self.arms, 0)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Reset the sum, count, and expectations to zero
         reset(self.arm_to_sum, 0)
@@ -28,7 +28,7 @@ class _EpsilonGreedy(BaseMAB):
 
         self._parallel_fit(decisions, rewards, contexts)
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         self._parallel_fit(decisions, rewards, contexts)
 
     def predict(self, contexts: np.ndarray = None) -> Arm:

--- a/mabwiser/linear.py
+++ b/mabwiser/linear.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
@@ -121,7 +121,7 @@ class _Linear(BaseMAB):
         self.arm_to_model = dict((arm, _Linear.factory.get(regression)(rng, l2_lambda,
                                                                        alpha, arm_to_scaler[arm])) for arm in arms)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Initialize each model by arm
         self.num_features = contexts.shape[1]
@@ -131,7 +131,7 @@ class _Linear(BaseMAB):
         # Perform parallel fit
         self._parallel_fit(decisions, rewards, contexts)
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         # Perform parallel fit
         self._parallel_fit(decisions, rewards, contexts)
 

--- a/mabwiser/mab.py
+++ b/mabwiser/mab.py
@@ -10,7 +10,7 @@ This module defines the public interface of the **MABWiser Library** providing a
     - ``NeighborhoodPolicy``
 """
 
-from typing import List, Union, Dict, NamedTuple, NoReturn, Callable, Optional
+from typing import List, Union, Dict, NamedTuple, Callable, Optional
 
 import numpy as np
 import pandas as pd
@@ -919,7 +919,7 @@ class MAB:
         else:
             return None
 
-    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> None:
         """ Adds an _arm_ to the list of arms.
 
         Incorporates the arm into the learning and neighborhood policies with no training data.
@@ -974,7 +974,7 @@ class MAB:
             rewards: Union[List[Num], np.ndarray, pd.Series],  # Rewards that are received
             contexts: Union[None, List[List[Num]],
                             np.ndarray, pd.Series, pd.DataFrame] = None  # Contexts, optional
-            ) -> NoReturn:
+            ) -> None:
         """Fits the multi-armed bandit to the given *decisions*, their corresponding *rewards*
         and *contexts*, if any.
 
@@ -1030,7 +1030,7 @@ class MAB:
     def partial_fit(self,
                     decisions: Union[List[Arm], np.ndarray, pd.Series],
                     rewards: Union[List[Num], np.ndarray, pd.Series],
-                    contexts: Union[None, List[List[Num]], np.ndarray, pd.Series, pd.DataFrame] = None) -> NoReturn:
+                    contexts: Union[None, List[List[Num]], np.ndarray, pd.Series, pd.DataFrame] = None) -> None:
         """Updates the multi-armed bandit with the given *decisions*, their corresponding *rewards*
         and *contexts*, if any.
 
@@ -1162,7 +1162,7 @@ class MAB:
         return self._imp.predict_expectations(contexts)
 
     @staticmethod
-    def _validate_mab_args(arms, learning_policy, neighborhood_policy, seed, n_jobs, backend) -> NoReturn:
+    def _validate_mab_args(arms, learning_policy, neighborhood_policy, seed, n_jobs, backend) -> None:
         """
         Validates arguments for the MAB constructor.
         """
@@ -1208,7 +1208,7 @@ class MAB:
         if backend is not None:
             check_true(isinstance(backend, str), TypeError("Parallel backend must be a string."))
 
-    def _validate_fit_args(self, decisions, rewards, contexts) -> NoReturn:
+    def _validate_fit_args(self, decisions, rewards, contexts) -> None:
         """"
         Validates argument types for fit and partial_fit functions.
         """
@@ -1246,7 +1246,7 @@ class MAB:
                         ValueError("Thompson Sampling requires binary rewards when binarizer function is not "
                                    "provided."))
 
-    def _validate_predict_args(self, contexts) -> NoReturn:
+    def _validate_predict_args(self, contexts) -> None:
         """"
         Validates argument types for predict and predict_expectation functions.
         """
@@ -1259,7 +1259,7 @@ class MAB:
             check_true(contexts is None, ValueError("Prediction with no context policy cannot handle context data."))
 
     @staticmethod
-    def _validate_context_type(contexts) -> NoReturn:
+    def _validate_context_type(contexts) -> None:
         """
         Validates that context data is 2D
         """

--- a/mabwiser/neighbors.py
+++ b/mabwiser/neighbors.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Callable, List, NoReturn, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import numpy as np
 from scipy.spatial.distance import cdist
@@ -37,7 +37,7 @@ class _Neighbors(BaseMAB):
         # When there are no neighbors, return nan expectations
         reset(self.arm_to_expectation, np.nan)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Set the historical data for prediction
         self.decisions = decisions
@@ -49,7 +49,7 @@ class _Neighbors(BaseMAB):
         else:
             self.rewards = rewards
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Binarize the rewards if using Thompson Sampling
         if isinstance(self.lp, _ThompsonSampling) and self.lp.binarizer:

--- a/mabwiser/popularity.py
+++ b/mabwiser/popularity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, NoReturn
+from typing import List, Optional
 import numpy as np
 
 from mabwiser.greedy import _EpsilonGreedy
@@ -15,7 +15,7 @@ class _Popularity(_EpsilonGreedy):
         # Init the parent greedy policy with zero epsilon
         super().__init__(rng, arms, n_jobs, backend, epsilon=0.0)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Fit as usual greedy
         super().fit(decisions, rewards, contexts)
@@ -23,7 +23,7 @@ class _Popularity(_EpsilonGreedy):
         # Make sure expectations sum up to 1 like probabilities
         self._normalize_expectations()
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Fit as usual greedy
         super().partial_fit(decisions, rewards, contexts)

--- a/mabwiser/rand.py
+++ b/mabwiser/rand.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
@@ -14,10 +14,10 @@ class _Random(BaseMAB):
     def __init__(self, rng: _BaseRNG, arms: List[Arm], n_jobs: int, backend: Optional[str]):
         super().__init__(rng, arms, n_jobs, backend)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         pass
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         pass
 
     def predict(self, contexts: np.ndarray = None) -> Arm:

--- a/mabwiser/simulator.py
+++ b/mabwiser/simulator.py
@@ -10,7 +10,7 @@ import logging
 from copy import deepcopy
 from collections import defaultdict
 from itertools import chain
-from typing import Union, List, Optional, NoReturn
+from typing import Union, List, Optional
 
 import math
 import matplotlib.pyplot as plt
@@ -338,7 +338,7 @@ class _KNearestSimulator(_NeighborsSimulator):
 
 
 class _ApproximateSimulator(_NeighborsSimulator, metaclass=abc.ABCMeta):
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
         super().fit(decisions, rewards, contexts)
 
         # Initialize planes
@@ -348,7 +348,7 @@ class _ApproximateSimulator(_NeighborsSimulator, metaclass=abc.ABCMeta):
         self._fit_operation(contexts, context_start=0)
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
         start = len(self.contexts)
 
         super().partial_fit(decisions, rewards, contexts)
@@ -755,7 +755,7 @@ class Simulator:
                 self.logger.info('No historic data for ' + str(arm))
         return stats
 
-    def plot(self, metric: str = 'avg', is_per_arm: bool = False) -> NoReturn:
+    def plot(self, metric: str = 'avg', is_per_arm: bool = False) -> None:
         """
         Generates a plot of the cumulative sum of the rewards for each bandit.
         Simulation must be run before calling this method.
@@ -884,7 +884,7 @@ class Simulator:
 
         plt.close('all')
 
-    def run(self) -> NoReturn:
+    def run(self) -> None:
         """ Run simulator
 
         Runs a simulation concurrently for all bandits in the bandits list.

--- a/mabwiser/softmax.py
+++ b/mabwiser/softmax.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import Dict, Callable, List, NoReturn, Optional, Union
+from typing import Dict, Callable, List, Optional, Union
 
 import numpy as np
 
@@ -23,7 +23,7 @@ class _Softmax(BaseMAB):
         self.arm_to_mean = dict.fromkeys(self.arms, 0)
         self.arm_to_exponent = dict.fromkeys(self.arms, 0)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Reset the sum, count, and expectations to zero
         reset(self.arm_to_sum, 0)
@@ -35,7 +35,7 @@ class _Softmax(BaseMAB):
         self._expectation_operation()
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
 
         # Calculate fit
         self._parallel_fit(decisions, rewards)

--- a/mabwiser/thompson.py
+++ b/mabwiser/thompson.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, NoReturn, Optional, Callable
+from typing import Dict, List, Optional, Callable
 
 import numpy as np
 
@@ -21,7 +21,7 @@ class _ThompsonSampling(BaseMAB):
         self.arm_to_success_count = dict.fromkeys(self.arms, 1)
         self.arm_to_fail_count = dict.fromkeys(self.arms, 1)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # If rewards are non binary, convert them
         rewards = self._get_binary_rewards(decisions, rewards)
@@ -36,7 +36,7 @@ class _ThompsonSampling(BaseMAB):
         # Leave the calculation of expectations to predict methods
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
 
         # If rewards are non binary, convert them
         rewards = self._get_binary_rewards(decisions, rewards)

--- a/mabwiser/treebandit.py
+++ b/mabwiser/treebandit.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 from copy import deepcopy
 from functools import partial
-from typing import Union, Dict, List, NoReturn, Optional, Callable
+from typing import Union, Dict, List, Optional, Callable
 
 import numpy as np
 from sklearn.tree import DecisionTreeRegressor
@@ -33,7 +33,7 @@ class _TreeBandit(BaseMAB):
         self.arm_to_tree = {arm: DecisionTreeRegressor(**self.tree_parameters) for arm in self.arms}
         self.arm_to_leaf_to_rewards = {arm: defaultdict(partial(np.ndarray, 0)) for arm in self.arms}
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Reset the decision tree and rewards of each arm
         self.arm_to_tree = {arm: DecisionTreeRegressor(**self.tree_parameters) for arm in self.arms}
@@ -48,7 +48,7 @@ class _TreeBandit(BaseMAB):
         # Calculate fit
         self._parallel_fit(decisions, rewards, contexts)
 
-    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # If TS and a binarizer function is given, binarize the rewards
         if isinstance(self.lp, _ThompsonSampling) and self.lp.binarizer:

--- a/mabwiser/ucb.py
+++ b/mabwiser/ucb.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
@@ -22,7 +22,7 @@ class _UCB1(BaseMAB):
         self.arm_to_count = dict.fromkeys(self.arms, 0)
         self.arm_to_mean = dict.fromkeys(self.arms, 0)
 
-    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
+    def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> None:
 
         # Reset the sum, count, and expectations to zero
         reset(self.arm_to_sum, 0)
@@ -37,7 +37,7 @@ class _UCB1(BaseMAB):
         self._parallel_fit(decisions, rewards)
 
     def partial_fit(self, decisions: np.ndarray, rewards: np.ndarray,
-                    contexts: Optional[np.ndarray] = None) -> NoReturn:
+                    contexts: Optional[np.ndarray] = None) -> None:
 
         # Update total number of decisions
         self.total_count += len(decisions)

--- a/mabwiser/utils.py
+++ b/mabwiser/utils.py
@@ -6,7 +6,7 @@ This module provides a number of constants and helper functions.
 """
 
 import abc
-from typing import Dict, Union, Iterable, NamedTuple, Tuple, NewType, NoReturn, List
+from typing import Dict, Union, Iterable, NamedTuple, Tuple, NewType, List
 
 import numpy as np
 
@@ -38,7 +38,7 @@ def argmax(dictionary: Dict[Arm, Num]) -> Arm:
     return max(dictionary, key=dictionary.get)
 
 
-def check_false(expression: bool, exception: Exception) -> NoReturn:
+def check_false(expression: bool, exception: Exception) -> None:
     """
     Checks that given expression is false, otherwise raises the given exception.
     """
@@ -46,7 +46,7 @@ def check_false(expression: bool, exception: Exception) -> NoReturn:
         raise exception
 
 
-def check_true(expression: bool, exception: Exception) -> NoReturn:
+def check_true(expression: bool, exception: Exception) -> None:
     """
     Checks that given expression is true, otherwise raises the given exception.
     """
@@ -54,7 +54,7 @@ def check_true(expression: bool, exception: Exception) -> NoReturn:
         raise exception
 
 
-def reset(dictionary: Dict, value) -> NoReturn:
+def reset(dictionary: Dict, value) -> None:
     """
     Maps every key to the given value.
     """


### PR DESCRIPTION
Thanks for the great library, and also taking the time to add type annotations for the users.

I've found some wrong uses of `typing.NoReturn` in the library, so I'm sending a PR to fix them. `NoReturn` return type annotations are for functions that never return a value, for instance those that exit the Python interpreter (by calling `sys.exit(1)`) or always raise an exception (by ending with `raise ValueError`). See: https://www.python.org/dev/peps/pep-0484/#the-noreturn-type

All Python functions that do not have a `return` statement returns `None`. Hence the correct return type annotation is `type(None)`, which is equivalent to simply `None` in the context of typing according to the standard. See: https://www.python.org/dev/peps/pep-0484/#using-none

I wasn't able to generate the documentations. I tried `pip install sphinx` and `make -C docsrc github` but it errored with:
```console
$ make -C docsrc github
Running Sphinx v4.4.0
WARNING: html_static_path entry '_static' does not exist
WARNING: sphinx_rtd_theme (< 0.3.0) found. It will not be available since Sphinx-6.0

Theme error:
no theme named 'sphinx_rtd_theme' found (missing theme.conf?)
make[1]: *** [html] Error 2
make: *** [github] Error 2
```

It'll help a lot for future contributors for the maintainers to add `docsrc/requirements.txt` or add dev dependencies to `setup.py`. In the meanwhile, please feel free to directly edit this branch if the documentation needs to be generated.