### PR TITLE
Scalers Refactor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@ March, 17, 2022 2.4.0
 major:
 - Implement vectorized functions for non-contextual policies to speed-up prediction for multiple decisions.
 - Change MAB predict and predict_expectations to allow empty contexts to be specified for non-contextual policies.
+- Update scaler use in Linear policies so that standard scaler can be fit directly instead of pre-trained scalers.
+- Change scaler argument from pre-trained `arm_to_scaler` input to a boolean scale flag.
 
 March, 8, 2022 2.3.0
 -------------------------------------------------------------------------------

--- a/mabwiser/base_mab.py
+++ b/mabwiser/base_mab.py
@@ -86,14 +86,14 @@ class BaseMAB(metaclass=abc.ABCMeta):
         self.cold_arm_to_warm_arm: Dict[Arm, Arm] = dict()
         self.trained_arms: List[Arm] = list()
 
-    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def add_arm(self, arm: Arm, binarizer: Callable = None) -> NoReturn:
         """Introduces a new arm to the bandit.
 
         Adds the new arm with zero expectations and
         calls the ``_uptake_new_arm()`` function of the sub-class.
         """
         self.arm_to_expectation[arm] = 0
-        self._uptake_new_arm(arm, binarizer, scaler)
+        self._uptake_new_arm(arm, binarizer)
 
     def remove_arm(self, arm: Arm) -> NoReturn:
         """Removes arm from the bandit.
@@ -146,7 +146,7 @@ class BaseMAB(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None) -> NoReturn:
         """Abstract method.
 
         Updates the multi-armed bandit with the new arm.

--- a/mabwiser/linear.py
+++ b/mabwiser/linear.py
@@ -153,13 +153,8 @@ class _Linear(BaseMAB):
 
     def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None):
 
-        # Create scaler
-        if self.scale:
-            scaler = StandardScaler()
-        else:
-            scaler = None
-
         # Add to untrained_arms arms
+        scaler = StandardScaler() if self.scale else None
         self.arm_to_model[arm] = _Linear.factory.get(self.regression)(self.rng, self.alpha, self.l2_lambda, scaler)
 
         # If fit happened, initialize the new arm to defaults

--- a/mabwiser/linear.py
+++ b/mabwiser/linear.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Callable, Dict, List, NoReturn, Optional
+from typing import Callable, List, NoReturn, Optional
 
 import numpy as np
+from sklearn.preprocessing import StandardScaler
 
 from mabwiser.base_mab import BaseMAB
 from mabwiser.utils import Arm, Num, argmax, _BaseRNG, create_rng
@@ -13,7 +14,7 @@ from mabwiser.utils import Arm, Num, argmax, _BaseRNG, create_rng
 class _RidgeRegression:
 
     def __init__(self, rng: _BaseRNG, alpha: Num = 1.0, l2_lambda: Num = 1.0, 
-                 scaler: Optional[Callable] = None):
+                 scaler: StandardScaler = None):
 
         # Ridge Regression: https://onlinecourses.science.psu.edu/stat857/node/155/
         self.rng = rng                      # random number generator
@@ -38,7 +39,12 @@ class _RidgeRegression:
 
         # Scale
         if self.scaler is not None:
-            X = self.scaler.transform(X.astype('float64'))
+            X = X.astype('float64')
+            if not hasattr(self.scaler, 'scale_'):
+                self.scaler.fit(X)
+            else:
+                self.scaler.partial_fit(X)
+            X = self.scaler.transform(X)
 
         # X transpose
         Xt = X.T
@@ -106,22 +112,25 @@ class _Linear(BaseMAB):
     factory = {"ts": _LinTS, "ucb": _LinUCB, "ridge": _RidgeRegression}
 
     def __init__(self, rng: _BaseRNG, arms: List[Arm], n_jobs: int, backend: Optional[str],
-                 alpha: Num, epsilon: Num, l2_lambda: Num, regression: str,
-                 arm_to_scaler: Optional[Dict[Arm, Callable]] = None):
+                 alpha: Num, epsilon: Num, l2_lambda: Num, regression: str, scale: bool):
         super().__init__(rng, arms, n_jobs, backend)
         self.alpha = alpha
         self.epsilon = epsilon
         self.l2_lambda = l2_lambda
         self.regression = regression
+        self.scale = scale
 
         # Create ridge regression model for each arm
         self.num_features = None
 
-        if arm_to_scaler is None:
-            arm_to_scaler = dict((arm, None) for arm in arms)
+        # Create scaler
+        if self.scale:
+            scaler = StandardScaler()
+        else:
+            scaler = None
 
-        self.arm_to_model = dict((arm, _Linear.factory.get(regression)(rng, alpha, 
-                                                                       l2_lambda, arm_to_scaler[arm])) for arm in arms)
+        # Create arm to model
+        self.arm_to_model = dict((arm, _Linear.factory.get(regression)(rng, alpha, l2_lambda, scaler)) for arm in arms)
 
     def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:
 
@@ -149,7 +158,13 @@ class _Linear(BaseMAB):
         for cold_arm, warm_arm in cold_arm_to_warm_arm.items():
             self.arm_to_model[cold_arm] = deepcopy(self.arm_to_model[warm_arm])
 
-    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None):
+    def _uptake_new_arm(self, arm: Arm, binarizer: Callable = None):
+
+        # Create scaler
+        if self.scale:
+            scaler = StandardScaler()
+        else:
+            scaler = None
 
         # Add to untrained_arms arms
         self.arm_to_model[arm] = _Linear.factory.get(self.regression)(self.rng, self.alpha, self.l2_lambda, scaler)

--- a/mabwiser/linear.py
+++ b/mabwiser/linear.py
@@ -119,17 +119,10 @@ class _Linear(BaseMAB):
         self.l2_lambda = l2_lambda
         self.regression = regression
         self.scale = scale
-
-        # Create ridge regression model for each arm
         self.num_features = None
 
-        # Create scaler
-        if self.scale:
-            scaler = StandardScaler()
-        else:
-            scaler = None
-
-        # Create arm to model
+        # Create regression model for each arm
+        scaler = StandardScaler() if self.scale else None
         self.arm_to_model = dict((arm, _Linear.factory.get(regression)(rng, alpha, l2_lambda, scaler)) for arm in arms)
 
     def fit(self, decisions: np.ndarray, rewards: np.ndarray, contexts: np.ndarray = None) -> NoReturn:

--- a/mabwiser/mab.py
+++ b/mabwiser/mab.py
@@ -859,13 +859,13 @@ class MAB:
             lp = _UCB1(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha)
         elif isinstance(learning_policy, LearningPolicy.LinGreedy):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, 0, learning_policy.epsilon,
-                          learning_policy.l2_lambda, "ridge", learning_policy.scale)
+                         learning_policy.l2_lambda, "ridge", learning_policy.scale)
         elif isinstance(learning_policy, LearningPolicy.LinTS):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha, 0,
-                          learning_policy.l2_lambda, "ts", learning_policy.scale)
+                         learning_policy.l2_lambda, "ts", learning_policy.scale)
         elif isinstance(learning_policy, LearningPolicy.LinUCB):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha, 0,
-                          learning_policy.l2_lambda, "ucb", learning_policy.scale)
+                         learning_policy.l2_lambda, "ucb", learning_policy.scale)
         else:
             check_true(False, ValueError("Undefined learning policy " + str(learning_policy)))
 

--- a/mabwiser/mab.py
+++ b/mabwiser/mab.py
@@ -15,7 +15,9 @@ from typing import List, Union, Dict, NamedTuple, NoReturn, Callable, Optional
 import numpy as np
 import pandas as pd
 from sklearn.cluster import MiniBatchKMeans
+from sklearn.preprocessing import MinMaxScaler, RobustScaler, StandardScaler
 from sklearn.tree import DecisionTreeClassifier
+
 
 from mabwiser._version import __author__, __email__, __version__, __copyright__
 from mabwiser.approximate import _LSHNearest
@@ -86,12 +88,10 @@ class LearningPolicy(NamedTuple):
             The regularization strength.
             Integer or float. Cannot be negative.
             Default value is 1.0.
-        arm_to_scaler: Dict[Arm, Callable]
-            Standardize context features by arm.
-            Dictionary mapping each arm to a scaler object. It is assumed
-            that the scaler objects are already fit and will only be used
-            to transform context features.
-            Default value is None.
+        scale: bool
+            Whether to scale features to have zero mean and unit variance.
+            Uses StandardScaler in sklearn.preprocessing.
+            Default value is False.
 
         Example
         -------
@@ -107,15 +107,14 @@ class LearningPolicy(NamedTuple):
         """
         epsilon: Num = 0.1
         l2_lambda: Num = 1.0
-        arm_to_scaler: Dict[Arm, Callable] = None
+        scale: bool = False
 
         def _validate(self):
             check_true(isinstance(self.epsilon, (int, float)), TypeError("Epsilon must be an integer or float."))
             check_true(0 <= self.epsilon <= 1, ValueError("Epsilon must be between zero and one."))
             check_true(isinstance(self.l2_lambda, (int, float)), TypeError("L2_lambda must be an integer or float."))
             check_true(0 <= self.l2_lambda, ValueError("The value of l2_lambda cannot be negative."))
-            if self.arm_to_scaler is not None:
-                check_true(isinstance(self.arm_to_scaler, dict), TypeError("Arm_to_scaler must be a dictionary"))
+            check_true(isinstance(self.scale, bool), TypeError("Standardize must be True or False."))
 
     class LinTS(NamedTuple):
         """ LinTS Learning Policy
@@ -148,12 +147,10 @@ class LearningPolicy(NamedTuple):
             The regularization strength.
             Integer or float. Must be greater than zero.
             Default value is 1.0.
-        arm_to_scaler: Dict[Arm, Callable]
-            Standardize context features by arm.
-            Dictionary mapping each arm to a scaler object. It is assumed
-            that the scaler objects are already fit and will only be used
-            to transform context features.
-            Default value is None.
+        scale: bool
+            Whether to scale features to have zero mean and unit variance.
+            Uses StandardScaler in sklearn.preprocessing.
+            Default value is False.
 
         Example
         -------
@@ -169,15 +166,14 @@ class LearningPolicy(NamedTuple):
         """
         alpha: Num = 1.0
         l2_lambda: Num = 1.0
-        arm_to_scaler: Dict[Arm, Callable] = None
+        scale: bool = False
 
         def _validate(self):
             check_true(isinstance(self.alpha, (int, float)), TypeError("Alpha must be an integer or float."))
             check_true(0 < self.alpha, ValueError("The value of alpha must be greater than zero."))
             check_true(isinstance(self.l2_lambda, (int, float)), TypeError("L2_lambda must be an integer or float."))
             check_true(0 < self.l2_lambda, ValueError("The value of l2_lambda must be greater than zero."))
-            if self.arm_to_scaler is not None:
-                check_true(isinstance(self.arm_to_scaler, dict), TypeError("Arm_to_scaler must be a dictionary"))
+            check_true(isinstance(self.scale, bool), TypeError("Scale must be True or False."))
 
     class LinUCB(NamedTuple):
         """LinUCB Learning Policy.
@@ -208,12 +204,10 @@ class LearningPolicy(NamedTuple):
             The regularization strength.
             Integer or float. Cannot be negative.
             Default value is 1.0.
-        arm_to_scaler: Dict[Arm, Callable]
-            Standardize context features by arm.
-            Dictionary mapping each arm to a scaler object. It is assumed
-            that the scaler objects are already fit and will only be used
-            to transform context features.
-            Default value is None.
+        scale: bool
+            Whether to scale features to have zero mean and unit variance.
+            Uses StandardScaler in sklearn.preprocessing.
+            Default value is False.
 
         Example
         -------
@@ -229,15 +223,14 @@ class LearningPolicy(NamedTuple):
         """
         alpha: Num = 1.0
         l2_lambda: Num = 1.0
-        arm_to_scaler: Dict[Arm, Callable] = None
+        scale: bool = False
 
         def _validate(self):
             check_true(isinstance(self.alpha, (int, float)), TypeError("Alpha must be an integer or float."))
             check_true(0 <= self.alpha, ValueError("The value of alpha cannot be negative."))
             check_true(isinstance(self.l2_lambda, (int, float)), TypeError("L2_lambda must be an integer or float."))
             check_true(0 <= self.l2_lambda, ValueError("The value of l2_lambda cannot be negative."))
-            if self.arm_to_scaler is not None:
-                check_true(isinstance(self.arm_to_scaler, dict), TypeError("Arm_to_scaler must be a dictionary"))
+            check_true(isinstance(self.scale, bool), TypeError("Scale must be True or False."))
 
     class Popularity(NamedTuple):
         """Randomized Popularity Learning Policy.
@@ -868,13 +861,13 @@ class MAB:
             lp = _UCB1(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha)
         elif isinstance(learning_policy, LearningPolicy.LinGreedy):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, 0, learning_policy.epsilon,
-                          learning_policy.l2_lambda, "ridge", learning_policy.arm_to_scaler)
+                          learning_policy.l2_lambda, "ridge", learning_policy.scale)
         elif isinstance(learning_policy, LearningPolicy.LinTS):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha, 0,
-                          learning_policy.l2_lambda, "ts", learning_policy.arm_to_scaler)
+                          learning_policy.l2_lambda, "ts", learning_policy.scale)
         elif isinstance(learning_policy, LearningPolicy.LinUCB):
             lp = _Linear(self._rng, self.arms, self.n_jobs, self.backend, learning_policy.alpha, 0,
-                          learning_policy.l2_lambda, "ucb", learning_policy.arm_to_scaler)
+                          learning_policy.l2_lambda, "ucb", learning_policy.scale)
         else:
             check_true(False, ValueError("Undefined learning policy " + str(learning_policy)))
 
@@ -936,15 +929,12 @@ class MAB:
             else:
                 return LearningPolicy.EpsilonGreedy(lp.epsilon)
         elif isinstance(lp, _Linear):
-            arm_to_scaler = dict()
-            for arm in lp.arms:
-                arm_to_scaler[arm] = lp.arm_to_model[arm].scaler
             if lp.regression == 'ridge':
-                return LearningPolicy.LinGreedy(lp.epsilon, lp.l2_lambda, arm_to_scaler)
+                return LearningPolicy.LinGreedy(lp.epsilon, lp.l2_lambda, lp.scale)
             elif lp.regression == 'ts':
-                return LearningPolicy.LinTS(lp.alpha, lp.l2_lambda, arm_to_scaler)
+                return LearningPolicy.LinTS(lp.alpha, lp.l2_lambda, lp.scale)
             elif lp.regression == 'ucb':
-                return LearningPolicy.LinUCB(lp.alpha, lp.l2_lambda, arm_to_scaler)
+                return LearningPolicy.LinUCB(lp.alpha, lp.l2_lambda, lp.scale)
             else:
                 check_true(False, ValueError("Undefined regression " + str(lp.regression)))
         elif isinstance(lp, _Random):
@@ -981,7 +971,7 @@ class MAB:
         else:
             return None
 
-    def add_arm(self, arm: Arm, binarizer: Callable = None, scaler: Callable = None) -> NoReturn:
+    def add_arm(self, arm: Arm, binarizer: Callable = None) -> NoReturn:
         """ Adds an _arm_ to the list of arms.
 
         Incorporates the arm into the learning and neighborhood policies with no training data.
@@ -992,8 +982,6 @@ class MAB:
             The new arm to be added.
         binarizer: Callable
             The new binarizer function for Thompson Sampling.
-        scaler: Callable
-            A scaler object from sklearn.preprocessing.
 
         Returns
         -------
@@ -1002,8 +990,6 @@ class MAB:
         Raises
         ------
         TypeError:  For ThompsonSampling, binarizer must be a callable function.
-        TypeError:  The standard scaler object must have a transform method.
-        TypeError:  The standard scaler object must be fit with calculated ``mean_`` and ``var_`` attributes.
 
         ValueError: A binarizer function was provided but the learning policy is not Thompson Sampling.
         ValueError: The arm already exists.
@@ -1020,17 +1006,11 @@ class MAB:
                                                       "success for a given arm decision. Specifically, the function "
                                                       "signature is binarize(arm: Arm, reward: Num) -> True/False "
                                                       "or 0/1"))
-
-        if scaler:
-            check_true(hasattr(scaler, 'transform'),
-                       TypeError("Scaler must be a scaler object from sklearn.preprocessing with a transform method"))
-            check_true(hasattr(scaler, 'mean_') and hasattr(scaler, 'var_'),
-                       TypeError("Scaler must be fit with calculated mean_ and var_ attributes"))
         check_false(arm in self.arms, ValueError("The arm is already in the list of arms."))
 
         self._validate_arm(arm)
         self.arms.append(arm)
-        self._imp.add_arm(arm, binarizer, scaler)
+        self._imp.add_arm(arm, binarizer)
 
     def remove_arm(self, arm: Arm) -> NoReturn:
         """Removes an _arm_ from the list of arms.

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -623,13 +623,9 @@ class InvalidTest(BaseTest):
                          is_predict=True,
                          n_jobs=0)
 
-    def test_invalid_add_arm_scaler(self):
-
-        scaler = StandardScaler()
-        arm_to_scaler = {0: deepcopy(scaler), 1: deepcopy(scaler)}
-        mab = MAB([0, 1], LearningPolicy.LinUCB(arm_to_scaler=arm_to_scaler))
+    def test_invalid_scale(self):
         with self.assertRaises(TypeError):
-            mab.add_arm(2, scaler=deepcopy(scaler))
+            mab = MAB([0, 1], LearningPolicy.LinUCB(scale=1))
 
     def test_convert_array_invalid(self):
         df = pd.DataFrame({'a': [1, 1, 1, 1, 1]})

--- a/tests/test_lingreedy.py
+++ b/tests/test_lingreedy.py
@@ -592,7 +592,53 @@ class LinGreedyTest(BaseTest):
         self.assertEqual(len(arm), 3)
         self.assertEqual(arm, [[3, 2], [3, 3], [3, 3]])
 
-    def test_scaler(self):
+    def test_scaler_values(self):
+        exp, mab = self.predict(arms=[1, 2, 3],
+                                decisions=[1, 1, 1, 2, 2, 3, 3, 3, 3, 3],
+                                rewards=[0, 0, 1, 0, 0, 0, 0, 1, 1, 1],
+                                learning_policy=LearningPolicy.LinGreedy(scale=True),
+                                context_history=[[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                 [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                 [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                 [0, 2, 1, 0, 0]],
+                                contexts=[[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]],
+                                seed=123456,
+                                num_run=1,
+                                is_predict=False)
+        self.assertEqual(mab._imp.arm_to_model[1].scaler.n_samples_seen_, 3)
+        self.assertEqual(mab._imp.arm_to_model[2].scaler.n_samples_seen_, 2)
+        self.assertEqual(mab._imp.arm_to_model[3].scaler.n_samples_seen_, 5)
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[1].scaler.mean_), [1/3, 2/3,  4/3, 4/3, 2.0])
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[2].scaler.mean_), [0.5, 2.5, 1.5, 2.0, 3.0])
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[3].scaler.mean_), [0.2, 1.2, 1.6, 1.6, 2.6])
+
+    def test_scaler_partial_fit(self):
+        exp, mab = self.predict(arms=[1, 2, 3],
+                                decisions=[1, 1, 1, 2, 2, 3, 3, 3, 3, 3],
+                                rewards=[0, 0, 1, 0, 0, 0, 0, 1, 1, 1],
+                                learning_policy=LearningPolicy.LinGreedy(scale=True),
+                                context_history=[[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                 [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                 [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                 [0, 2, 1, 0, 0]],
+                                contexts=[[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]],
+                                seed=123456,
+                                num_run=1,
+                                is_predict=False)
+        mab.partial_fit(decisions=[3, 3, 3, 2, 2, 1, 1, 1, 1, 1],
+                        rewards=[0, 0, 1, 0, 0, 0, 0, 1, 1, 1],
+                        contexts=[[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                  [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                  [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                  [0, 2, 1, 0, 0]])
+        self.assertEqual(mab._imp.arm_to_model[1].scaler.n_samples_seen_, 8)
+        self.assertEqual(mab._imp.arm_to_model[2].scaler.n_samples_seen_, 4)
+        self.assertEqual(mab._imp.arm_to_model[3].scaler.n_samples_seen_, 8)
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[1].scaler.mean_), [0.25, 1.0, 1.5, 1.5, 2.375])
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[2].scaler.mean_), [0.5, 2.5, 1.5, 2.0, 3.0])
+        self.assertListAlmostEqual(list(mab._imp.arm_to_model[3].scaler.mean_), [0.25, 1.0, 1.5, 1.5, 2.375])
+
+    def test_scaler_predictions(self):
 
         arms = [1, 2, 3]
         context_history = np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
@@ -604,6 +650,7 @@ class LinGreedyTest(BaseTest):
         decisions = np.array([1, 1, 1, 2, 2, 3, 3, 3, 3, 3])
         rewards = np.array([0, 0, 1, 0, 0, 0, 0, 1, 1, 1])
 
+
         arm_to_scaler = {}
         for arm in arms:
             scaler = StandardScaler()
@@ -614,7 +661,7 @@ class LinGreedyTest(BaseTest):
         exp, mab = self.predict(arms=arms,
                                 decisions=decisions,
                                 rewards=rewards,
-                                learning_policy=LearningPolicy.LinGreedy(arm_to_scaler=arm_to_scaler),
+                                learning_policy=LearningPolicy.LinGreedy(scale=True),
                                 context_history=context_history,
                                 contexts=contexts,
                                 seed=123456,

--- a/tests/test_lints.py
+++ b/tests/test_lints.py
@@ -14,93 +14,72 @@ from tests.test_base import BaseTest
 class LinTSTest(BaseTest):
 
     def test_alpha0_0001(self):
-        scaler = StandardScaler()
-        context_history = np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
-                                                 [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
-                                                 [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
-                                                 [0, 2, 1, 0, 0]])
-        scaler.fit(context_history)
-
         arm, mab = self.predict(arms=[1, 2, 3],
                                 decisions=[1, 1, 1, 2, 2, 2, 3, 3, 3, 1],
                                 rewards=[0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
-                                learning_policy=LearningPolicy.LinTS(alpha=0.0001,
-                                                                     arm_to_scaler={1: scaler, 2: scaler, 3: scaler}),
-                                context_history=context_history,
+                                learning_policy=LearningPolicy.LinTS(alpha=0.0001, scale=True),
+                                context_history=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                         [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                         [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                         [0, 2, 1, 0, 0]]),
                                 contexts=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]]),
                                 seed=123456,
                                 num_run=3,
                                 is_predict=True)
 
         self.assertEqual(len(arm), 3)
-        self.assertEqual(arm, [[3, 2], [3, 2], [3, 2]])
+        self.assertEqual(arm, [[2, 3], [2, 3], [3, 3]])
 
     def test_alpha0_0001_expectations(self):
-        scaler = StandardScaler()
-        context_history = np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
-                                    [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
-                                    [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
-                                    [0, 2, 1, 0, 0]])
-        scaler.fit(context_history)
-
         exps, mab = self.predict(arms=[1, 2, 3],
                                  decisions=[1, 1, 1, 2, 2, 2, 3, 3, 3, 1],
                                  rewards=[0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
-                                 learning_policy=LearningPolicy.LinTS(alpha=0.0001,
-                                                                      arm_to_scaler={1: scaler, 2: scaler, 3: scaler}),
-                                 context_history=context_history,
+                                 learning_policy=LearningPolicy.LinTS(alpha=0.0001, scale=True),
+                                 context_history=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                          [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                          [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                          [0, 2, 1, 0, 0]]),
                                  contexts=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]]),
                                  seed=123456,
                                  num_run=1,
                                  is_predict=False)
 
-        self.assertListAlmostEqual(exps[0].values(), [-0.2852569197274552, 0.00016338898274687822, 0.5735155717025586])
-        self.assertListAlmostEqual(exps[1].values(), [-0.1487907884038659, -7.802191785859073e-05,
-                                                      -0.0008484936824155465])
+        self.assertListAlmostEqual(exps[0].values(),
+                                   [-0.23459369004297587, 0.0002702455674444537, 4.588547880979047e-05])
+        self.assertListAlmostEqual(exps[1].values(),
+                                   [-0.192811601170233, -2.3415795345448245e-05, 0.00016619626256880228])
 
     def test_alpha1(self):
-        scaler = StandardScaler()
-        context_history = np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
-                                    [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
-                                    [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
-                                    [0, 2, 1, 0, 0]])
-        scaler.fit(context_history)
-
         arm, mab = self.predict(arms=[1, 2, 3],
                                 decisions=[1, 1, 1, 2, 2, 3, 3, 3, 3, 3],
                                 rewards=[0, 0, 1, 0, 0, 0, 0, 1, 1, 1],
-                                learning_policy=LearningPolicy.LinTS(alpha=1,
-                                                                     arm_to_scaler={1: scaler, 2: scaler, 3: scaler}),
-                                context_history=context_history,
+                                learning_policy=LearningPolicy.LinTS(alpha=1),
+                                context_history=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                         [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                         [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                         [0, 2, 1, 0, 0]]),
                                 contexts=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]]),
                                 seed=123456,
                                 num_run=1,
                                 is_predict=True)
-
         self.assertEqual(len(arm), 2)
         self.assertEqual(arm, [2, 3])
 
     def test_alpha1_expectations(self):
-        scaler = StandardScaler()
-        context_history = np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
-                                    [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
-                                    [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
-                                    [0, 2, 1, 0, 0]])
-        scaler.fit(context_history)
-
         exps, mab = self.predict(arms=[1, 2, 3],
                                  decisions=[1, 1, 1, 2, 2, 3, 3, 3, 3, 3],
                                  rewards=[0, 0, 1, 0, 0, 0, 0, 1, 1, 1],
-                                 learning_policy=LearningPolicy.LinTS(alpha=1,
-                                                                      arm_to_scaler={1: scaler, 2: scaler, 3: scaler}),
-                                 context_history=context_history,
+                                 learning_policy=LearningPolicy.LinTS(alpha=1),
+                                 context_history=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0],
+                                                           [0, 2, 2, 3, 5], [1, 3, 1, 1, 1], [0, 0, 0, 0, 0],
+                                                           [0, 1, 4, 3, 5], [0, 1, 2, 4, 5], [1, 2, 1, 1, 3],
+                                                           [0, 2, 1, 0, 0]]),
                                  contexts=np.array([[0, 1, 2, 3, 5], [1, 1, 1, 1, 1]]),
                                  seed=123456,
                                  num_run=1,
                                  is_predict=False)
-
-        self.assertListAlmostEqual(exps[0].values(), [-0.6846042491588905, 1.8728586982060706, 0.39597711947956443])
-        self.assertListAlmostEqual(exps[1].values(), [-0.9156881567627143, -1.01000793116177, 1.6774048483779203])
+        self.assertListAlmostEqual(exps[0].values(), [-0.6029872358950072, 3.105765259323796, 1.0208598325762464])
+        self.assertListAlmostEqual(exps[1].values(), [0.572141413757231, 0.45473267178654997, 1.773376616755168])
 
     def test_np(self):
 

--- a/tests/test_linucb.py
+++ b/tests/test_linucb.py
@@ -559,7 +559,7 @@ class LinUCBTest(BaseTest):
         exp, mab = self.predict(arms=arms,
                                 decisions=decisions,
                                 rewards=rewards,
-                                learning_policy=LearningPolicy.LinUCB(arm_to_scaler=arm_to_scaler),
+                                learning_policy=LearningPolicy.LinUCB(scale=True),
                                 context_history=context_history,
                                 contexts=contexts,
                                 seed=123456,
@@ -585,14 +585,6 @@ class LinUCBTest(BaseTest):
 
             for i in range(len(contexts)):
                 self.assertAlmostEqual(exp[i][arm], exp_check[i][arm])
-
-    @staticmethod
-    def test_add_arm_scaler():
-        scaler = StandardScaler()
-        scaler.fit(np.array([[1, 2, 3, 4, 5], [5, 4, 3, 2, 1]]).astype('float64'))
-        arm_to_scaler = {0: deepcopy(scaler), 1: deepcopy(scaler)}
-        mab = MAB([0, 1], LearningPolicy.LinUCB(arm_to_scaler=arm_to_scaler))
-        mab.add_arm(2, scaler=deepcopy(scaler))
 
     def test_add_arm(self):
         arm, mab = self.predict(arms=[1, 2, 3],

--- a/tests/test_mab.py
+++ b/tests/test_mab.py
@@ -46,17 +46,11 @@ class MABTest(BaseTest):
         mab = MAB([0, 1], lp)
         self.assertEqual(lp.epsilon, mab.learning_policy.epsilon)
 
-        data = np.array([[1, 2, 3], [3, 2, 1]])
-        sc = StandardScaler()
-        sc.fit(data)
-        arm_to_scaler = {0: sc, 1: sc}
-
-        lp = LearningPolicy.LinUCB(alpha=2.0, l2_lambda=0.3, arm_to_scaler=arm_to_scaler)
+        lp = LearningPolicy.LinUCB(alpha=2.0, l2_lambda=0.3, scale=True)
         mab = MAB([0, 1], lp)
         self.assertEqual(lp.alpha, mab.learning_policy.alpha)
         self.assertEqual(lp.l2_lambda, mab.learning_policy.l2_lambda)
-        self.assertIs(sc, mab.learning_policy.arm_to_scaler[0])
-        self.assertIs(sc, mab.learning_policy.arm_to_scaler[1])
+        self.assertEqual(lp.scale, mab.learning_policy.scale)
 
         lp = LearningPolicy.Softmax(tau=0.5)
         mab = MAB([0, 1], lp)

--- a/tests/test_ridge.py
+++ b/tests/test_ridge.py
@@ -17,7 +17,7 @@ class RidgeRegressionTest(BaseTest):
         rewards = np.array([3, 3, 1])
         rng = np.random.RandomState(seed=7)
 
-        ridge = _RidgeRegression(rng, l2_lambda=1.0, alpha=1.0, scaler = None)
+        ridge = _RidgeRegression(rng, l2_lambda=1.0, alpha=1.0, scaler=None)
 
         ridge.init(context.shape[1])
         ridge.fit(context, rewards)
@@ -31,7 +31,7 @@ class RidgeRegressionTest(BaseTest):
         scaler = StandardScaler()
         scaler.fit(context.astype('float64'))
 
-        ridge = _RidgeRegression(rng, l2_lambda=1.0, alpha=1.0, scaler = scaler)
+        ridge = _RidgeRegression(rng, l2_lambda=1.0, alpha=1.0, scaler=scaler)
 
         ridge.init(context.shape[1])
         ridge.fit(context, rewards)


### PR DESCRIPTION
* Fit scalers in MABWiser instead of having an `arm_to_scaler` input that requires each scaler to be pre-fit.