### PR TITLE
Cron schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '30 13 * * 1' # Runs every Monday at 8:30 AM
+    - cron: '30 12 * * 1' # Runs every Monday at 8:30 AM EST
 
 jobs:
   Test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '30 12 * * 1' # Runs every Monday at 8:30 AM EST
+    - cron: '00 12 * * 1' # Runs every Monday at 8:00 AM EST
 
 jobs:
   Test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '*/10 * * * *'
 
 jobs:
   Test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '30 13 * * 1' # Runs every Monday at 8:30 AM
 
 jobs:
   Test:


### PR DESCRIPTION
### Changes
- Added a weekly scheduling of the CI job that runs the tests on the library
 
### Outcomes
- The workflow previously would only run tests against PR's and now it would also run on every Monday at 8:30 AM EST